### PR TITLE
Fixed Readme documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This engine includes: Battle, Overworld, Multi-language supports, and other feat
 
 If you like this project, please star it and follow it on [GameJolt](https://gamejolt.com/games/undertale_engine/378055)!
 
-We also have a [document page](https://tml233.github.io/undertale_engine/#/), but it is not finished yet.
+We also have a [document page](https://tml233.github.io/UndertaleEngine/#/), but it is not finished yet.
 
 ## Examples
 There is a example branch. Once you have downloaded it and opened it, you can click the "Views" button on the resources panel, and switch the views to checkout different examples.


### PR DESCRIPTION
Readme.md currently has a dead link which can be easily changed and help people bumping into 404