### PR TITLE
Added window_center() at Border_SetEnabled | 在Border_SetEnabled中添加window_center()

### DIFF
--- a/scripts/Border_SetEnabled/Border_SetEnabled.gml
+++ b/scripts/Border_SetEnabled/Border_SetEnabled.gml
@@ -18,6 +18,7 @@ function Border_SetEnabled() {
 			border._sprite_previous=-1;
 		}
 	}
+	if(!window_get_fullscreen()){window_center();}
 	return true;
 
 


### PR DESCRIPTION
GameMaker更新后 设置窗口大小的操作不会自动居中窗口
需要手动执行window_center()函数

After GameMaker updated, setting the window size wont automatically center the window
Need to manual execute function window_center()