### PR TITLE
Fixed hard-coded save slot | 修复了硬编码的存档槽位

### DIFF
--- a/objects/ui_save/Other_10.gml
+++ b/objects/ui_save/Other_10.gml
@@ -24,7 +24,7 @@ if(_state==0){
 	_inst_return.text=_prefix+Lang_GetString("ui.save.return");
 }
 if(_state==1){
-	Player_Save(0);
+	Player_Save(Flag_GetSaveSlot());
 	
 	audio_play_sound(snd_save,0,false);
 	


### PR DESCRIPTION
In ui_save, only file0 will be save, no matter which save slot was set
Replace the 0 with Flag_GetSaveSlot() can fix that

在 ui_save 中，只有 0 号存档会被保存，无论设置的是哪个存档槽位
把 0 替换为 Flag_GetSaveSlot() 即可修复